### PR TITLE
Added `Default` support for struct ctor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "derive-ctor"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-ctor"
-version = "0.2.0"
+version = "0.2.1"
 description = "Adds `#[derive(ctor)]` which allows for the auto-generation of a constructor."
 keywords = ["derive", "macro", "trait", "procedural", "no_std"]
 authors = ["Evan Cowin"]

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 - Customize the name and visibility of the auto-generated constructor using `#[ctor(visibility method_name)]`.
   - Supports const constructors by adding the "const" keyword.
   - Provide a list of names to generate multiple constructors.
-- Customize field behavior in the constructor with the following attributes:
-  - `#[ctor(cloned)]` - Changes the parameter type to accept a reference type which is then cloned into the created struct.
-  - `#[ctor(default)]` - Exclude the field from the generated method and use its default value.
-  - `#[ctor(expr(EXPRESSION))]` - Exclude the field from the generated method and use the defined expression as its default value.
-    - Use `#[ctor(expr!(EXPRESSION))]` to add the annotated field as a required parameter, allowing the expression to reference itself.
-    - Use `#[ctor(expr(TYPE -> EXPRESSION))]` to add a parameter with the specified type, which will be used to generate the final field value.
-  - `#[ctor(into)]` - Change the parameter type for the generated method to `impl Into<Type>`.
-  - `#[ctor(iter(FROM_TYPE))]` - Change the parameter type for the generated method to `impl IntoIterator<Item=FROM_TYPE>`.
+- Customize field behavior in the constructor with the following properties (used in `#[ctor(PROPETY)])`:
+  - **cloned** - Changes the parameter type to accept a reference type which is then cloned into the created struct.
+  - **default** - Exclude the field from the generated method and use its default value.
+  - **expr(EXPRESSION)** - Exclude the field from the generated method and use the defined expression as its default value.
+    - **expr!(EXPRESSION)** to add the annotated field as a required parameter, allowing the expression to reference itself.
+    - Use **expr(TYPE -> EXPRESSION)** to add a parameter with the specified type, which will be used to generate the final field value.
+  - **into** - Change the parameter type for the generated method to `impl Into<Type>`.
+  - **iter(FROM_TYPE)** - Change the parameter type for the generated method to `impl IntoIterator<Item=FROM_TYPE>`.
 - Support no-std via `features = ["no-std"]`
 
 ## Basic Usage
@@ -24,7 +24,7 @@ Add `derive-ctor` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-derive-ctor = "0.1.1"
+derive-ctor = "0.2.1"
 ```
 
 Import the crate in your Rust code:
@@ -48,6 +48,8 @@ let my_struct = MyStruct::new(1, String::from("Foo"));
 
 ## Struct Configurations
 
+### Visibiltiy and Construtor Name
+
 You can modify the name and visibility of the generated method, and define additional
 constructors by using the `#[ctor]` attribute on the target struct after `ctor` is derived.
 
@@ -58,11 +60,33 @@ These methods all inherit their respective visibilities defined within the `#[ct
 use derive_ctor::ctor;
 
 #[derive(ctor)]
-#[ctor(pub new, pub(crate) with_defaults, const internal)]
+#[ctor(pub new, pub(crate) other, const internal)]
 struct MyStruct {
     field1: i32,
     field2: String
 }
+
+let my_struct1 = MyStruct::new(100, "A".to_string());
+let my_struct2 = MyStruct::other(200, "B".to_string());
+let my_struct3 = MyStruct::internal(300, "C".to_string());
+```
+
+### Auto-implement "Default" Trait
+The `Default` trait can be auto implemented by specifying a ctor with the name "Default" in the ctor attribute. Note: all fields must have a generated value in order for the implementation to be valid.
+
+```rust
+use derive_ctor::ctor;
+
+#[derive(ctor)]
+#[ctor(Default)]
+struct MyStruct {
+    #[ctor(default)]
+    field1: i32,
+    #[ctor(expr(true))]
+    field2: bool
+}
+
+let default: MyStruct = Default::default();
 ```
 
 ## Enum Configurations

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -9,7 +9,7 @@ use alloc::string::ToString;
 use std::collections::HashSet;
 
 
-use proc_macro2::{Delimiter, Punct};
+use proc_macro2::{Delimiter, Punct, Span};
 use proc_macro2::Spacing::Alone;
 use quote::{quote, TokenStreamExt, ToTokens};
 use syn::{Error, Ident, LitInt, token, Type, Token};
@@ -54,13 +54,16 @@ pub(crate) enum FieldConfigProperty {
 #[derive(Clone)]
 pub(crate) struct ParameterField {
     pub(crate) field_ident: Ident,
-    pub(crate) field_type: Type
+    pub(crate) field_type: Type,
+    pub(crate) span: Span
 }
 
 #[derive(Clone)]
 pub(crate) struct GeneratedField {
     pub(crate) field_ident: Ident,
-    pub(crate) configuration: FieldConfigProperty
+    pub(crate) configuration: FieldConfigProperty,
+    #[allow(dead_code /*may be used for future purposes*/)]
+    pub(crate) span: Span
 }
 
 impl Parse for FieldConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
 #![cfg_attr(feature = "no-std", no_std, doc = "Removes all std library dependencies within library.")]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "no-std")]
+extern crate alloc;
+#[cfg(feature = "no-std")]
+use alloc::format;
+#[cfg(feature = "no-std")]
+use alloc::string::ToString;
+
+
 use proc_macro::TokenStream;
 use proc_macro2::Delimiter;
 use quote::ToTokens;

--- a/tests/enum_variant_config.rs
+++ b/tests/enum_variant_config.rs
@@ -18,7 +18,7 @@ fn test_variant_with_configured_ctors() {
 #[derive(ctor, Debug, PartialEq)]
 enum EnumNoVariantGeneration {
     Variant1,
-    #[ctor(none)]
+    #[ctor(none)] #[allow(dead_code)]
     Variant2
 }
 
@@ -34,7 +34,7 @@ enum VariantConfigOverridesDefaults {
     Variant1,
     #[ctor(variant2)]
     Variant2,
-    #[ctor(none)]
+    #[ctor(none)] #[allow(dead_code)]
     Variant3
 }
 

--- a/tests/struct_ctor_config.rs
+++ b/tests/struct_ctor_config.rs
@@ -56,3 +56,41 @@ fn test_field_struct_with_custom_ctor_name() {
     let field_struct = FieldStructCustomCtor::init(15);
     assert_eq!(FieldStructCustomCtor { value: 15 }, field_struct);
 }
+
+#[derive(Debug, PartialEq)]
+struct NoDefault {
+
+}
+
+#[derive(ctor, Debug, PartialEq)]
+#[ctor(Default)]
+struct DefaultCtorStruct {
+    #[ctor(expr(NoDefault {}))]
+    name: NoDefault,
+    #[ctor(default)]
+    value: i32
+}
+
+#[test]
+fn test_struct_with_default_ctor() {
+    let result = Default::default();
+    assert_eq!(DefaultCtorStruct { name: NoDefault {}, value: 0 }, result);
+}
+
+#[derive(ctor, Debug, PartialEq)]
+#[ctor(pub new, Default)]
+struct TestDefaultCtorWithTargetedFieldConfig {
+    #[ctor(expr(String::from("Default")) = 1)]
+    name: String,
+    #[ctor(expr(404) = 1)]
+    value: u32
+}
+
+#[test]
+fn test_struct_with_targeted_field_default_ctor() {
+    let non_default = TestDefaultCtorWithTargetedFieldConfig::new(String::from("Foo"), 505);
+    assert_eq!(TestDefaultCtorWithTargetedFieldConfig { name: String::from("Foo"), value: 505 }, non_default);
+
+    let default = Default::default();
+    assert_eq!(TestDefaultCtorWithTargetedFieldConfig { name: String::from("Default"), value: 404}, default);
+}

--- a/tests/struct_field_all.rs
+++ b/tests/struct_field_all.rs
@@ -1,3 +1,8 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::String;
 use derive_ctor::ctor;
 
 #[derive(ctor, Debug, PartialEq)]


### PR DESCRIPTION
- added #[ctor(Default)] as a configuration for structs which allows for the auto-implementation of the `Default` trait
- fixed the `no-std` feature
- cleaned up README