### PR TITLE
Added default(all) and split crate into multiple features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "derive-ctor"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "derive-ctor"
-version = "0.2.2"
-description = "Adds `#[derive(ctor)]` which allows for the auto-generation of a constructor."
+version = "0.2.3"
+description = "Adds `#[derive(ctor)]` which allows for the auto-generation of struct and enum constructors."
 keywords = ["derive", "macro", "trait", "procedural", "no_std"]
 authors = ["Evan Cowin"]
 license = "MIT"
@@ -10,6 +10,11 @@ edition = "2021"
 exclude = [".github/*", ".gitignore"]
 categories = ["no-std", "rust-patterns"]
 
+[features]
+default = ["structs", "enums"]
+enums = ["dep:heck"]
+structs = []
+
 [lib]
 proc-macro = true
 
@@ -17,4 +22,4 @@ proc-macro = true
 syn = { version = "2.0.*" }
 quote = { version = "1.*" }
 proc-macro2 = { version = "1.0.*" }
-heck = { version = "0.5.*" }
+heck = { version = "0.5.*", optional = true }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `derive-ctor` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-derive-ctor = "0.2.2"
+derive-ctor = "0.2.3"
 ```
 
 Annotate your struct with `#[derive(ctor)]` to automatically generate a `new` constructor:
@@ -68,13 +68,14 @@ let my_struct3 = MyStruct::internal(300, "C".to_string());
 ```
 
 ### Auto-implement "Default" Trait
-The `Default` trait can be auto implemented by specifying a ctor with the name "Default" in the ctor attribute. Note: all fields must have a generated value in order for the implementation to be valid.
+The `Default` trait can be auto implemented by specifying a ctor with the name `default` in the ctor attribute. Note: all fields must have a generated value in order for the implementation to be valid.
+Additionally, declaring `default(all)` will automatically mark all non-annotated fields with `#[ctor(default)]`
 
 ```rust
 use derive_ctor::ctor;
 
 #[derive(ctor)]
-#[ctor(Default)]
+#[ctor(default)]
 struct MyStruct {
     #[ctor(default)]
     field1: i32,
@@ -83,6 +84,17 @@ struct MyStruct {
 }
 
 let default: MyStruct = Default::default();
+
+
+#[derive(ctor)]
+#[ctor(default(all))]
+struct OtherStruct {
+    field1: i32,
+    #[ctor(expr(true))]
+    field2: bool
+}
+
+let default2: OtherStruct = Default::default();
 ```
 
 ## Enum Configurations

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,31 @@
+// while redundant this file exists as a possible user-reference to discover all possible properties
+// available to them for a certain element
+
+
+// error messages
+pub(crate) const CONFIG_PROP_ERR_MSG: &str =
+    "Unexpected property: \"{prop}\" (must be one of the following: \"{values}\")";
+pub(crate) const DEFAULT_CTOR_ERR_MSG: &str =
+    "Default constructor requires field to generate its own value.";
+
+pub(crate) const CTOR_WORD: &str = "ctor";
+
+// valid field properties
+pub(crate) const FIELD_PROP_CLONED: &str = "cloned";
+pub(crate) const FIELD_PROP_DEFAULT: &str = "default";
+pub(crate) const FIELD_PROP_EXPR: &str = "expr";
+pub(crate) const FIELD_PROP_INTO: &str = "into";
+pub(crate) const FIELD_PROP_ITER: &str = "iter";
+
+// valid enum-config properties
+pub(crate) const ENUM_PROP_PREFIX: &str = "prefix";
+pub(crate) const ENUM_PROP_VISIBILITY: &str = "visibility";
+pub(crate) const ENUM_PROP_VIS: &str = "vis";
+
+// variation property
+pub(crate) const ENUM_VARIATION_PROP_NONE: &str = "none";
+
+// struct config properties
+pub(crate) const STRUCT_PROP_DEFAULT: &str = "default";
+// property used within the default() prop
+pub(crate) const NESTED_PROP_ALL: &str = "all";

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,47 +1,61 @@
 use proc_macro::TokenStream;
 
-use alloc::vec;
 use alloc::string::ToString;
+use alloc::vec;
 use alloc::vec::Vec;
+
+#[cfg(feature = "enums")]
 use heck::ToSnakeCase;
 
+use crate::constants::{CONFIG_PROP_ERR_MSG, ENUM_PROP_VIS as VIS, ENUM_PROP_VISIBILITY as VISIBILITY, ENUM_PROP_PREFIX as PREFIX};
+use crate::structs::{CtorAttribute, CtorDefinition, CtorStructConfiguration, };
+use crate::try_parse_attributes_with_default;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{Data, DeriveInput, Error, Fields, Generics, Ident, token, Variant, Visibility};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::{Comma, Pub};
-use crate::{CONFIG_PROP_ERR_MSG, try_parse_attributes_with_default};
-use crate::structs::{generate_ctor_meta_from_fields, CtorAttribute, CtorDefinition, CtorStructConfiguration};
+use syn::{token, Data, DeriveInput, Error, Fields, Generics, Ident, Variant, Visibility};
+use crate::fields::generate_ctor_meta;
 
 static ENUM_CTOR_PROPS: &str = "\"prefix\", \"visibility\", \"vis\"";
 
 enum EnumConfigItem {
     Visibility { visibility: Visibility },
-    Prefix { prefix: Ident }
+    Prefix { prefix: Ident },
 }
 
 struct CtorEnumConfiguration {
     prefix: Option<Ident>,
-    default_visibility: Visibility
+    default_visibility: Visibility,
 }
 
 impl Default for CtorEnumConfiguration {
     fn default() -> Self {
-        Self { prefix: None, default_visibility: Visibility::Public(Pub { span: Span::mixed_site() }) }
+        Self {
+            prefix: None,
+            default_visibility: Visibility::Public(Pub {
+                span: Span::mixed_site(),
+            }),
+        }
     }
 }
 
 impl CtorStructConfiguration {
     fn from_variant(configuration: &CtorEnumConfiguration, variant_name: Ident) -> Self {
-        Self { definitions: vec![CtorDefinition {
-            visibility: configuration.default_visibility.clone(),
-            ident: match &configuration.prefix {
-                None => variant_name,
-                Some(prefix) => syn::parse_str(&(prefix.to_string() + "_" + &variant_name.to_string())).unwrap()
-            },
-            attributes: Default::default(),
-        }], is_none: false }
+        Self {
+            definitions: vec![CtorDefinition {
+                visibility: configuration.default_visibility.clone(),
+                ident: match &configuration.prefix {
+                    None => variant_name,
+                    Some(prefix) => {
+                        syn::parse_str(&(prefix.to_string() + "_" + &variant_name.to_string())).unwrap()
+                    }
+                },
+                attrs: Default::default(),
+            }],
+            is_none: false,
+        }
     }
 }
 
@@ -50,7 +64,9 @@ impl Parse for CtorEnumConfiguration {
         let mut configuration = CtorEnumConfiguration::default();
         loop {
             match input.parse::<EnumConfigItem>()? {
-                EnumConfigItem::Visibility { visibility } => configuration.default_visibility = visibility,
+                EnumConfigItem::Visibility { visibility } => {
+                    configuration.default_visibility = visibility
+                }
                 EnumConfigItem::Prefix { prefix } => configuration.prefix = Some(prefix),
             }
             if input.parse::<Comma>().is_err() {
@@ -69,38 +85,52 @@ impl Parse for EnumConfigItem {
         input.parse::<token::Eq>()?;
 
         Ok(match property_name.as_str() {
-            "vis" | "visibility" => EnumConfigItem::Visibility { visibility: input.parse()? },
-            "prefix" => EnumConfigItem::Prefix { prefix: input.parse()? },
-            _ => return Err(Error::new(
-                property.span(),
-                CONFIG_PROP_ERR_MSG.replace("{prop}", &property_name).replace("{values}", ENUM_CTOR_PROPS)
-            ))
+            VIS | VISIBILITY => EnumConfigItem::Visibility { visibility: input.parse()?, },
+            PREFIX => EnumConfigItem::Prefix { prefix: input.parse()?, },
+            _ => {
+                return Err(Error::new(property.span(),
+                    CONFIG_PROP_ERR_MSG
+                        .replace("{prop}", &property_name)
+                        .replace("{values}", ENUM_CTOR_PROPS),
+                ))
+            }
         })
     }
 }
 
+#[cfg(not(feature = "enums"))]
+pub(crate) fn create_enum_token_stream(derive_input: DeriveInput) -> TokenStream {
+    use syn::spanned::Spanned;
+    TokenStream::from(Error::new(Span::call_site(),
+        "\"enums\" feature must be enabled to use #[derive(ctor)] on enums.").to_compile_error())
+}
+
+#[cfg(feature = "enums")]
 pub(crate) fn create_enum_token_stream(derive_input: DeriveInput) -> TokenStream {
     if let Data::Enum(data) = derive_input.data {
-        let configuration = match try_parse_attributes_with_default(&derive_input.attrs, || CtorEnumConfiguration::default()) {
+        let configuration = match try_parse_attributes_with_default(&derive_input.attrs, || { 
+            CtorEnumConfiguration::default()
+        }) {
             Ok(config) => config,
-            Err(err) => return TokenStream::from(err.to_compile_error())
+            Err(err) => return TokenStream::from(err.to_compile_error()),
         };
 
         return create_ctor_enum_impl(
             derive_input.ident,
             derive_input.generics,
             data.variants,
-            configuration
-        )
+            configuration,
+        );
     }
     panic!("Expected Enum data")
 }
 
+#[cfg(feature = "enums")]
 fn create_ctor_enum_impl(
     ident: Ident,
     generics: Generics,
     variants: Punctuated<Variant, Comma>,
-    configuration: CtorEnumConfiguration
+    configuration: CtorEnumConfiguration,
 ) -> TokenStream {
     let mut methods = Vec::new();
 
@@ -108,42 +138,44 @@ fn create_ctor_enum_impl(
         let variant_code = match &variant.fields {
             Fields::Named(_) => 0,
             Fields::Unnamed(_) => 1,
-            Fields::Unit => 2
+            Fields::Unit => 2,
         };
 
         let variant_name = variant.ident;
-        let variant_config = match try_parse_attributes_with_default(&variant.attrs, || CtorStructConfiguration::from_variant(
-            &configuration,
-            variant_name.clone()
-        )) {
+        let variant_config = match try_parse_attributes_with_default(&variant.attrs, || {
+            CtorStructConfiguration::from_variant(&configuration, variant_name.clone())
+        }) {
             Ok(config) => config,
-            Err(err) => return TokenStream::from(err.to_compile_error())
+            Err(err) => return TokenStream::from(err.to_compile_error()),
         };
-        
+
         // stop generation of method if none
         if variant_config.is_none {
             continue;
         }
-    
-        let meta = match generate_ctor_meta_from_fields(variant.fields, variant_config.definitions.len()) {
-            Ok(meta) => meta,
-            Err(err) => return TokenStream::from(err.into_compile_error()),
-        };
 
-        let field_idents = meta.field_idents;
-
-        for (i, definition) in variant_config.definitions.into_iter().enumerate() {
-            let method_req_fields = &meta.parameter_fields[i];
-            let method_gen_fields = &meta.generated_fields[i];
-    
-            let visibility = definition.visibility;
-            let name = match convert_to_snakecase(definition.ident) {
-                Ok(snake_case_ident) => snake_case_ident,
-                Err(err) => return TokenStream::from(err.to_compile_error())
+        for (i, def) in variant_config.definitions.into_iter().enumerate() {
+            let meta = match generate_ctor_meta(&def.attrs, &variant.fields, i) {
+                Ok(meta) => meta,
+                Err(err) => return TokenStream::from(err.into_compile_error()),
             };
 
-            let const_tkn = if definition.attributes.contains(&CtorAttribute::Const) { quote! { const } } else { quote!{} };
-    
+            let field_idents = meta.field_idents;
+            let parameter_fields = meta.parameter_fields;
+            let generated_fields = meta.generated_fields;
+
+            let visibility = def.visibility;
+            let name = match convert_to_snakecase(def.ident) {
+                Ok(snake_case_ident) => snake_case_ident,
+                Err(err) => return TokenStream::from(err.to_compile_error()),
+            };
+
+            let const_tkn = if def.attrs.contains(&CtorAttribute::Const) {
+                quote! { const }
+            } else {
+                quote! {}
+            };
+
             let enum_generation = if variant_code == 0 {
                 quote! { Self::#variant_name { #(#field_idents),* } }
             } else if variant_code == 1 {
@@ -153,8 +185,8 @@ fn create_ctor_enum_impl(
             };
 
             methods.push(quote! {
-                #visibility #const_tkn fn #name(#(#method_req_fields),*) -> Self {
-                    #(#method_gen_fields)*
+                #visibility #const_tkn fn #name(#(#parameter_fields),*) -> Self {
+                    #(#generated_fields)*
                     #enum_generation
                 }
             })
@@ -170,32 +202,70 @@ fn create_ctor_enum_impl(
     })
 }
 
+#[cfg(feature = "enums")]
 fn convert_to_snakecase(method_ident: Ident) -> Result<Ident, Error> {
     let ident_string = method_ident.to_string();
     let trimmed_start_str = ident_string.trim_start_matches('_');
     let trimmed_start_end_str = trimmed_start_str.trim_end_matches('_');
-    
+
     let leading_underscore_count = ident_string.len() - trimmed_start_str.len();
     let trailing_underscore_count = trimmed_start_str.len() - trimmed_start_end_str.len();
-    
-    let snake_case = "_".repeat(leading_underscore_count) 
-        + &ident_string.to_snake_case() + &"_".repeat(trailing_underscore_count);
-    
+
+    let snake_case = "_".repeat(leading_underscore_count)
+        + &ident_string.to_snake_case()
+        + &"_".repeat(trailing_underscore_count);
+
     syn::parse_str(&snake_case)
 }
 
-#[test]
+#[test] #[cfg(feature = "enums")]
 fn test_convert_to_snakecase() {
-    assert_eq!(convert_to_snakecase(Ident::new("A", Span::mixed_site())).unwrap(), Ident::new("a", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("Test", Span::mixed_site())).unwrap(), Ident::new("test", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("Test1", Span::mixed_site())).unwrap(), Ident::new("test1", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("ONETWO", Span::mixed_site())).unwrap(), Ident::new("onetwo", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("OneTwo", Span::mixed_site())).unwrap(), Ident::new("one_two", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("__Abc__", Span::mixed_site())).unwrap(), Ident::new("__abc__", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("A_B", Span::mixed_site())).unwrap(), Ident::new("a_b", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("A_b", Span::mixed_site())).unwrap(), Ident::new("a_b", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("abCdEf", Span::mixed_site())).unwrap(), Ident::new("ab_cd_ef", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("one_2_three", Span::mixed_site())).unwrap(), Ident::new("one_2_three", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("ending_", Span::mixed_site())).unwrap(), Ident::new("ending_", Span::mixed_site()));
-    assert_eq!(convert_to_snakecase(Ident::new("endinG_", Span::mixed_site())).unwrap(), Ident::new("endin_g_", Span::mixed_site()));
+    assert_eq!(
+        convert_to_snakecase(Ident::new("A", Span::mixed_site())).unwrap(),
+        Ident::new("a", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("Test", Span::mixed_site())).unwrap(),
+        Ident::new("test", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("Test1", Span::mixed_site())).unwrap(),
+        Ident::new("test1", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("ONETWO", Span::mixed_site())).unwrap(),
+        Ident::new("onetwo", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("OneTwo", Span::mixed_site())).unwrap(),
+        Ident::new("one_two", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("__Abc__", Span::mixed_site())).unwrap(),
+        Ident::new("__abc__", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("A_B", Span::mixed_site())).unwrap(),
+        Ident::new("a_b", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("A_b", Span::mixed_site())).unwrap(),
+        Ident::new("a_b", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("abCdEf", Span::mixed_site())).unwrap(),
+        Ident::new("ab_cd_ef", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("one_2_three", Span::mixed_site())).unwrap(),
+        Ident::new("one_2_three", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("ending_", Span::mixed_site())).unwrap(),
+        Ident::new("ending_", Span::mixed_site())
+    );
+    assert_eq!(
+        convert_to_snakecase(Ident::new("endinG_", Span::mixed_site())).unwrap(),
+        Ident::new("endin_g_", Span::mixed_site())
+    );
 }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,20 +1,26 @@
 extern crate alloc;
 use alloc::collections::BTreeSet as HashSet;
 use alloc::string::ToString;
+use alloc::vec::Vec;
 
-
-use proc_macro2::{Delimiter, Punct, Span};
 use proc_macro2::Spacing::Alone;
-use quote::{quote, TokenStreamExt, ToTokens};
-use syn::{Error, Ident, LitInt, token, Type, Token};
+use proc_macro2::{Delimiter, Punct, Span};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::discouraged::AnyDelimiter;
-use syn::parse::{ParseStream, Parse};
+use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::token::{Comma, Impl};
+use syn::{parse2, token, Error, Fields, Ident, LitInt, Token, Type};
 
-use crate::{consume_delimited, CONFIG_PROP_ERR_MSG};
+use crate::constants::{
+    CONFIG_PROP_ERR_MSG, FIELD_PROP_CLONED as CLONED, FIELD_PROP_DEFAULT as DEFAULT,
+    FIELD_PROP_EXPR as EXPR, FIELD_PROP_INTO as INTO, FIELD_PROP_ITER as ITER,
+};
+use crate::structs::CtorAttribute;
+use crate::structs::CtorAttribute::DefaultAll;
+use crate::{consume_delimited, is_phantom_data, try_parse_attributes};
 
-static FIELD_PROPS: &str = "\"cloned\", \"default\", \"expr\", \"into\", \"iter\"";
+const FIELD_PROPS: &str = "\"cloned\", \"default\", \"expr\", \"into\", \"iter\"";
 
 /// Represents a configuration on a struct field
 ///
@@ -33,7 +39,7 @@ static FIELD_PROPS: &str = "\"cloned\", \"default\", \"expr\", \"into\", \"iter\
 #[derive(Clone)]
 pub(crate) struct FieldConfig {
     pub(crate) property: FieldConfigProperty,
-    pub(crate) applications: HashSet<usize>
+    pub(crate) applications: HashSet<usize>,
 }
 
 #[derive(Clone)]
@@ -41,15 +47,28 @@ pub(crate) enum FieldConfigProperty {
     Cloned,
     Default,
     Into,
-    Iter { iter_type: Type },
-    Expression { expression: proc_macro2::TokenStream, input_type: Option<Type>, self_referencing: bool }
+    Iter {
+        iter_type: Type,
+    },
+    Expression {
+        expression: proc_macro2::TokenStream,
+        input_type: Option<Type>,
+        self_referencing: bool,
+    },
+}
+
+#[derive(Default)]
+pub(crate) struct ConstructorMeta {
+    pub(crate) field_idents: Vec<Ident>,
+    pub(crate) parameter_fields: Vec<ParameterField>,
+    pub(crate) generated_fields: Vec<GeneratedField>,
 }
 
 #[derive(Clone)]
 pub(crate) struct ParameterField {
     pub(crate) field_ident: Ident,
     pub(crate) field_type: Type,
-    pub(crate) span: Span
+    pub(crate) span: Span,
 }
 
 #[derive(Clone)]
@@ -57,33 +76,37 @@ pub(crate) struct GeneratedField {
     pub(crate) field_ident: Ident,
     pub(crate) configuration: FieldConfigProperty,
     #[allow(dead_code /*may be used for future purposes*/)]
-    pub(crate) span: Span
+    pub(crate) span: Span,
 }
 
 impl Parse for FieldConfig {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut config = FieldConfig {
             property: input.parse()?,
-            applications: HashSet::default()
+            applications: HashSet::default(),
         };
 
         if input.parse::<token::Eq>().is_err() {
-            return Ok(config)
+            return Ok(config);
         }
 
         // consume constructor specifier ex: 1, 2, 3
         if let Ok((delim, span, buffer)) = input.parse_any_delimiter() {
             if delim != Delimiter::Bracket {
-                return Err(Error::new(span.span(), "Expected enclosing brackets"))
+                return Err(Error::new(span.span(), "Expected enclosing brackets"));
             }
             loop {
-                config.applications.insert(buffer.parse::<LitInt>()?.base10_parse()?);
+                config
+                    .applications
+                    .insert(buffer.parse::<LitInt>()?.base10_parse()?);
                 if buffer.parse::<Comma>().is_err() {
                     break;
                 }
             }
         } else {
-            config.applications.insert(input.parse::<LitInt>()?.base10_parse()?);
+            config
+                .applications
+                .insert(input.parse::<LitInt>()?.base10_parse()?);
         }
 
         Ok(config)
@@ -95,20 +118,20 @@ impl Parse for FieldConfigProperty {
         if let Ok(token) = input.parse::<Impl>() {
             return Err(Error::new(
                 token.span(),
-                "\"impl\" property has been renamed to \"into\"."
+                "\"impl\" property has been renamed to \"into\".",
             ));
         }
 
         let property: Ident = input.parse()?;
         let property_name = property.to_string();
         match property_name.as_str() {
-            "cloned" => Ok(FieldConfigProperty::Cloned),
-            "default" => Ok(FieldConfigProperty::Default),
-            "into" => Ok(FieldConfigProperty::Into),
-            "iter" => consume_delimited(input, Delimiter::Parenthesis, |buffer| {
+            CLONED => Ok(FieldConfigProperty::Cloned),
+            DEFAULT => Ok(FieldConfigProperty::Default),
+            INTO => Ok(FieldConfigProperty::Into),
+            ITER => consume_delimited(input, Delimiter::Parenthesis, |buffer| {
                 Ok(FieldConfigProperty::Iter { iter_type: buffer.parse()? })
             }),
-            "expr" => {
+            EXPR => {
                 let self_referencing = input.parse::<Token![!]>().is_ok();
 
                 consume_delimited(input, Delimiter::Parenthesis, |buffer| {
@@ -166,4 +189,90 @@ impl ToTokens for GeneratedField {
 
         tokens.append(Punct::new(';', Alone))
     }
+}
+
+pub(crate) fn generate_ctor_meta(
+    ctor_attributes: &HashSet<CtorAttribute>,
+    fields: &Fields,
+    ctor_index: usize,
+) -> Result<ConstructorMeta, Error> {
+    let mut meta = ConstructorMeta::default();
+
+    for (field_index, field) in fields.iter().enumerate() {
+        let configuration = try_parse_attributes::<FieldConfig>(&field.attrs)?;
+
+        let span = field.span();
+
+        let field_ident = field.ident.clone().unwrap_or_else(|| {
+            Ident::new(
+                &("arg".to_string() + &field_index.to_string()),
+                Span::mixed_site(),
+            )
+        });
+
+        meta.field_idents.push(field_ident.clone());
+
+        let field_ident = field_ident.clone();
+        let ft = &field.ty;
+
+        let mut req_field_type = None;
+        let mut gen_configuration = None;
+
+        match &configuration {
+            None if ctor_attributes.contains(&DefaultAll) => {
+                gen_configuration = Some(FieldConfigProperty::Default)
+            }
+            None if is_phantom_data(&field.ty) => {
+                gen_configuration = Some(FieldConfigProperty::Default)
+            }
+            None => req_field_type = Some(field.ty.clone()),
+            Some(configuration) => {
+                let applications = &configuration.applications;
+                gen_configuration = Some(configuration.property.clone());
+
+                if applications.is_empty() || applications.contains(&ctor_index) {
+                    // create a required field type if the configuration requires an additional input parameter
+                    req_field_type = match &configuration.property {
+                        FieldConfigProperty::Cloned => Some(parse2(quote! { &#ft }).unwrap()),
+                        FieldConfigProperty::Into => {
+                            Some(parse2(quote! { impl Into<#ft> }).unwrap())
+                        }
+                        FieldConfigProperty::Iter { iter_type } => {
+                            Some(parse2(quote! { impl IntoIterator<Item=#iter_type> }).unwrap())
+                        }
+                        FieldConfigProperty::Expression { input_type, .. }
+                            if input_type.is_some() =>
+                        {
+                            input_type.clone()
+                        }
+                        FieldConfigProperty::Expression {
+                            self_referencing, ..
+                        } if *self_referencing => Some(field.ty.clone()),
+                        _ => None,
+                    }
+                } else if is_phantom_data(&field.ty) {
+                    gen_configuration = Some(FieldConfigProperty::Default);
+                } else {
+                    gen_configuration = None;
+                    req_field_type = Some(field.ty.clone());
+                }
+            }
+        }
+
+        if let Some(cfg) = gen_configuration {
+            meta.generated_fields.push(GeneratedField {
+                field_ident: field_ident.clone(),
+                configuration: cfg,
+                span,
+            })
+        }
+        if let Some(field_type) = req_field_type {
+            meta.parameter_fields.push(ParameterField {
+                field_ident,
+                field_type,
+                span,
+            })
+        }
+    }
+    Ok(meta)
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,60 +1,66 @@
 extern crate alloc;
-use alloc::vec;
-use alloc::vec::Vec;
+
 use alloc::collections::BTreeSet as HashSet;
 use alloc::string::ToString;
-
+use alloc::vec;
+use alloc::vec::Vec;
 use proc_macro::TokenStream;
 
-use proc_macro2::Span;
+use proc_macro2::{Delimiter, Span};
 use quote::quote;
-use syn::spanned::Spanned;
-use syn::{parse2, Data, DeriveInput, Error, Fields, Generics, Ident, Visibility};
-use syn::parse::{ParseStream, Parse};
+use syn::{Data, DeriveInput, Error, Fields, Generics, Ident, Visibility};
+use syn::parse::{Parse, ParseStream};
 use syn::token::{Comma, Const, Pub};
 
-use crate::fields::{FieldConfig, FieldConfigProperty, GeneratedField, ParameterField};
-use crate::{is_phantom_data, try_parse_attributes, try_parse_attributes_with_default};
+use CtorAttribute::DefaultAll;
 
-static DEFAULT_CTOR_ERR_MSG: &'static str = "Default constructor requires field to generate its own value.";
+use crate::{consume_delimited, try_parse_attributes_with_default};
+use crate::constants::{DEFAULT_CTOR_ERR_MSG, ENUM_VARIATION_PROP_NONE as NONE, NESTED_PROP_ALL as ALL, STRUCT_PROP_DEFAULT as DEFAULT};
+use crate::fields::generate_ctor_meta;
 
 pub(crate) struct CtorDefinition {
     pub(crate) visibility: Visibility,
     pub(crate) ident: Ident,
-    pub(crate) attributes: HashSet<CtorAttribute>
+    pub(crate) attrs: HashSet<CtorAttribute>,
 }
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum CtorAttribute {
     Const,
-    Default
+    DefaultAll,
+    Default,
 }
 
 impl Default for CtorDefinition {
     fn default() -> Self {
         Self {
-            visibility: Visibility::Public(Pub { span: Span::call_site() }),
+            visibility: Visibility::Public(Pub {
+                span: Span::call_site(),
+            }),
             ident: Ident::new("new", Span::mixed_site()),
-            attributes: Default::default()
+            attrs: Default::default(),
         }
     }
 }
 
 pub(crate) struct CtorStructConfiguration {
     pub(crate) definitions: Vec<CtorDefinition>,
-    pub(crate) is_none: bool
+    pub(crate) is_none: bool,
 }
 
 impl Default for CtorStructConfiguration {
     fn default() -> Self {
-        Self { definitions: vec![CtorDefinition::default()], is_none: false }
+        Self {
+            definitions: vec![CtorDefinition::default()],
+            is_none: false,
+        }
     }
 }
 
 impl Parse for CtorStructConfiguration {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.is_empty() {
-            return Ok(Self::default())
+            return Ok(Self::default());
         }
 
         let mut definitions = Vec::new();
@@ -74,24 +80,36 @@ impl Parse for CtorStructConfiguration {
                 CtorDefinition {
                     visibility,
                     ident: input.parse()?,
-                    attributes
+                    attrs: attributes,
                 }
             } else {
                 let ident = input.parse::<Ident>()?;
-                
+
                 match ident.to_string().as_str() {
                     // check for "none" as first parameter, if exists return early (this is only applicable for enums)
-                    "none" if definitions.is_empty() => {
-                        return Ok(CtorStructConfiguration { definitions: Default::default(), is_none: true })
-                    },
-                    "Default" => { attributes.insert(CtorAttribute::Default); },
+                    NONE if definitions.is_empty() => {
+                        return Ok(CtorStructConfiguration {
+                            definitions: Default::default(),
+                            is_none: true,
+                        })
+                    }
+                    DEFAULT => {
+                        if let Ok(true) =
+                            consume_delimited(input, Delimiter::Parenthesis, |buffer| {
+                                Ok(buffer.parse::<Ident>()?.to_string() == ALL)
+                            })
+                        {
+                            attributes.insert(DefaultAll);
+                        }
+                        attributes.insert(CtorAttribute::Default);
+                    }
                     _ => {}
                 }
-                
+
                 CtorDefinition {
                     visibility: Visibility::Inherited,
                     ident,
-                    attributes
+                    attrs: attributes,
                 }
             };
 
@@ -103,23 +121,35 @@ impl Parse for CtorStructConfiguration {
             }
         }
 
-        Ok(Self { definitions, is_none: false })
+        Ok(Self {
+            definitions,
+            is_none: false,
+        })
     }
 }
 
+#[cfg(not(feature = "structs"))]
+pub(crate) fn create_struct_token_stream(derive_input: DeriveInput) -> TokenStream {
+    TokenStream::from(Error::new(Span::call_site(),
+        "\"structs\" feature must be enabled to use #[derive(ctor)] on structs.").to_compile_error())
+}
+
+#[cfg(feature = "structs")]
 pub(crate) fn create_struct_token_stream(derive_input: DeriveInput) -> TokenStream {
     if let Data::Struct(data) = derive_input.data {
-        let configuration = match try_parse_attributes_with_default(&derive_input.attrs, || CtorStructConfiguration::default()) {
+        let configuration = match try_parse_attributes_with_default(&derive_input.attrs, || {
+            CtorStructConfiguration::default()
+        }) {
             Ok(config) => config,
-            Err(err) => return TokenStream::from(err.to_compile_error())
+            Err(err) => return TokenStream::from(err.to_compile_error()),
         };
 
         return create_ctor_struct_impl(
             derive_input.ident,
             derive_input.generics,
             data.fields,
-            configuration
-        )
+            configuration,
+        );
     }
     panic!("Expected Struct data")
 }
@@ -128,48 +158,55 @@ fn create_ctor_struct_impl(
     ident: Ident,
     generics: Generics,
     fields: Fields,
-    configuration: CtorStructConfiguration
+    configuration: CtorStructConfiguration,
 ) -> TokenStream {
-    let meta = match generate_ctor_meta_from_fields(fields, configuration.definitions.len()) {
-        Ok(meta) => meta,
-        Err(err) => return TokenStream::from(err.into_compile_error()),
-    };
-
-    let field_idents = meta.field_idents;
-
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let mut methods = Vec::new();
     let mut default_method = None;
+
     for (i, definition) in configuration.definitions.into_iter().enumerate() {
-        let method_req_fields = &meta.parameter_fields[i];
-        let method_gen_fields = &meta.generated_fields[i];
+        let meta = match generate_ctor_meta(&definition.attrs, &fields, i) {
+            Ok(meta) => meta,
+            Err(err) => return TokenStream::from(err.into_compile_error()),
+        };
+
+        let field_idents = meta.field_idents;
+        let parameter_fields = meta.parameter_fields;
+        let generated_fields = meta.generated_fields;
 
         let visibility = definition.visibility;
         let mut name = definition.ident;
-        let const_tkn = if definition.attributes.contains(&CtorAttribute::Const) 
-            { quote! { const } } else { quote!{} };
+        let const_tkn = if definition.attrs.contains(&CtorAttribute::Const) {
+            quote! { const }
+        } else {
+            quote! {}
+        };
 
-        let is_default = definition.attributes.contains(&CtorAttribute::Default);
+        let is_default = definition.attrs.contains(&CtorAttribute::Default);
+
         if is_default {
             name = syn::parse_str("default").unwrap();
         }
 
         let method_token_stream = quote! {
-            #visibility #const_tkn fn #name(#(#method_req_fields),*) -> Self {
-                #(#method_gen_fields)*
+            #visibility #const_tkn fn #name(#(#parameter_fields),*) -> Self {
+                #(#generated_fields)*
                 Self { #(#field_idents),* }
             }
         };
 
         if is_default {
-            if !method_req_fields.is_empty() {
-                let first_error = Error::new(method_req_fields[0].span, DEFAULT_CTOR_ERR_MSG);
-                let errors = method_req_fields.into_iter().skip(1).fold(first_error, |mut e, f| {
-                    e.combine(Error::new(f.span, DEFAULT_CTOR_ERR_MSG));
-                    e
-                });
-                return TokenStream::from(errors.to_compile_error())
+            if !parameter_fields.is_empty() {
+                let first_error = Error::new(parameter_fields[0].span, DEFAULT_CTOR_ERR_MSG);
+                let errors = parameter_fields
+                    .into_iter()
+                    .skip(1)
+                    .fold(first_error, |mut e, f| {
+                        e.combine(Error::new(f.span, DEFAULT_CTOR_ERR_MSG));
+                        e
+                    });
+                return TokenStream::from(errors.to_compile_error());
             }
             default_method = Some(method_token_stream);
         } else {
@@ -183,7 +220,9 @@ fn create_ctor_struct_impl(
                 #def_method
             }
         }
-    } else { quote!{} };
+    } else {
+        quote! {}
+    };
 
     TokenStream::from(quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
@@ -191,86 +230,4 @@ fn create_ctor_struct_impl(
         }
         #default_impl
     })
-}
-
-pub(crate) struct ConstructorMeta {
-    pub(crate) parameter_fields: Vec<Vec<ParameterField>>,
-    pub(crate) generated_fields: Vec<Vec<GeneratedField>>,
-    pub(crate) field_idents: Vec<Ident>
-}
-
-impl ConstructorMeta {
-    pub(crate) fn new(method_count: usize) -> ConstructorMeta {
-        ConstructorMeta {
-            parameter_fields: vec![Default::default(); method_count],
-            generated_fields: vec![Default::default(); method_count],
-            field_idents: Default::default()
-        }
-    }
-}
-
-
-pub(crate) fn generate_ctor_meta_from_fields(fields: Fields, method_count: usize) -> Result<ConstructorMeta, Error> {
-    let mut meta = ConstructorMeta::new(method_count);
-    for (field_index, field) in fields.into_iter().enumerate() {
-        let configuration = try_parse_attributes::<FieldConfig>(&field.attrs)?;
-
-        let span = field.span();
-
-        let field_ident = field.ident.unwrap_or_else(|| {
-            Ident::new(&("arg".to_string() + &field_index.to_string()), Span::mixed_site())
-        });
-
-        meta.field_idents.push(field_ident.clone());
-
-        
-        for i in 0..method_count {
-
-            let field_ident = field_ident.clone();
-            let ft = &field.ty;
-
-            let mut req_field_type = None;
-            let mut gen_configuration = None;
-
-            match &configuration {
-                None if is_phantom_data(&field.ty) => gen_configuration = Some(FieldConfigProperty::Default),
-                None => req_field_type = Some(field.ty.clone()),
-                Some(configuration) => {
-                    let applications = &configuration.applications;
-                    gen_configuration = Some(configuration.property.clone());
-                    
-                    if applications.is_empty() || applications.contains(&i) {
-                        // create a required field type if the configuration requires an additional input parameter
-                        req_field_type = match &configuration.property {
-                            FieldConfigProperty::Cloned => Some(parse2(quote! { &#ft }).unwrap()),
-                            FieldConfigProperty::Into => Some(parse2(quote! { impl Into<#ft> }).unwrap()),
-                            FieldConfigProperty::Iter { iter_type } => Some(parse2(quote! { impl IntoIterator<Item=#iter_type> }).unwrap()),
-                            FieldConfigProperty::Expression { input_type, .. } if input_type.is_some() => input_type.clone(),
-                            FieldConfigProperty::Expression { self_referencing, .. } if *self_referencing => Some(field.ty.clone()),
-                            _ => None
-                        }
-                    } else if is_phantom_data(&field.ty) {
-                        gen_configuration = Some(FieldConfigProperty::Default);
-                    } else {
-                        gen_configuration = None;
-                        req_field_type = Some(field.ty.clone());
-                    }
-                }
-            }
-            
-            
-
-            if let Some(cfg) = gen_configuration {
-                meta.generated_fields[i].push(GeneratedField {
-                    field_ident: field_ident.clone(),
-                    configuration: cfg,
-                    span
-                })
-            }
-            if let Some(field_type) = req_field_type {
-                meta.parameter_fields[i].push(ParameterField { field_ident, field_type, span })
-            }
-        }
-    }
-    Ok(meta)
 }

--- a/tests/enum_base.rs
+++ b/tests/enum_base.rs
@@ -2,27 +2,27 @@ use derive_ctor::ctor;
 
 #[derive(ctor, Debug, PartialEq)]
 enum EnumUnitVariant {
-    Variant1
+    Variant1,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 enum EnumStructVariant {
-    Variant { field: i32 }
+    Variant { field: i32 },
 }
 
 #[derive(ctor, Debug, PartialEq)]
 enum EnumNamelessVariant {
-    Variant(i32)
+    Variant(i32),
 }
 
 #[test]
 fn test_enum_variants() {
     let unit = EnumUnitVariant::variant1();
     assert_eq!(EnumUnitVariant::Variant1, unit);
-    
+
     let struct_variant = EnumStructVariant::variant(13);
     assert_eq!(EnumStructVariant::Variant { field: 13 }, struct_variant);
-    
+
     let nameless_variant = EnumNamelessVariant::variant(95);
     assert_eq!(EnumNamelessVariant::Variant(95), nameless_variant);
 }
@@ -31,17 +31,17 @@ fn test_enum_variants() {
 enum MultipleVariants {
     Variant1,
     Variant2(i32),
-    Variant3 { value: usize }
+    Variant3 { value: usize },
 }
 
 #[test]
 fn test_enum_multiple_variants() {
     let v1 = MultipleVariants::variant1();
     assert_eq!(MultipleVariants::Variant1, v1);
-    
+
     let v2 = MultipleVariants::variant2(123);
     assert_eq!(MultipleVariants::Variant2(123), v2);
-    
+
     let v3 = MultipleVariants::variant3(888);
     assert_eq!(MultipleVariants::Variant3 { value: 888 }, v3);
 }

--- a/tests/enum_default_config.rs
+++ b/tests/enum_default_config.rs
@@ -5,7 +5,7 @@ use derive_ctor::ctor;
 enum PrefixEnum {
     Variant1,
     Variant2(i32),
-    Variant3 { value: i32 }
+    Variant3 { value: i32 },
 }
 
 #[test]
@@ -21,7 +21,7 @@ fn test_variants_with_prefix() {
 #[derive(ctor)]
 #[ctor(vis = pub(crate))]
 enum VisibilityEnum {
-    Element
+    Element,
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn test_visibility_enum() {
 #[derive(ctor)]
 #[ctor(prefix = new, visibility = pub(crate))]
 enum PrefixAndVisibilityEnum {
-    Element
+    Element,
 }
 
 #[test]

--- a/tests/enum_unnamed_variants.rs
+++ b/tests/enum_unnamed_variants.rs
@@ -2,7 +2,7 @@ use derive_ctor::ctor;
 
 #[derive(ctor, Debug, PartialEq)]
 enum UnnamedVariantEnum {
-    One(#[ctor(default)] i32)
+    One(#[ctor(default)] i32),
 }
 
 #[test]
@@ -13,30 +13,36 @@ fn test_unnamed_variant_property() {
 
 #[derive(ctor, Debug, PartialEq)]
 enum UnnamedVariantEnumMultipleFields {
-    Many(i32, #[ctor(expr(false))] bool, #[ctor(into)] String)
+    Many(i32, #[ctor(expr(false))] bool, #[ctor(into)] String),
 }
 
 #[test]
 fn test_unnamed_variant_multiple_properties() {
     let result = UnnamedVariantEnumMultipleFields::many(50, "FooBar");
-    assert_eq!(UnnamedVariantEnumMultipleFields::Many(50, false, String::from("FooBar")), result);
+    assert_eq!(
+        UnnamedVariantEnumMultipleFields::Many(50, false, String::from("FooBar")),
+        result
+    );
 }
 
 #[derive(ctor, Debug, PartialEq)]
 enum EnumMultipleUnnamedVariants {
     One(i32),
     Two(bool, #[ctor(default)] String),
-    Three(#[ctor(cloned)] String)
+    Three(#[ctor(cloned)] String),
 }
 
 #[test]
 fn test_multiple_enum_variants() {
     let one = EnumMultipleUnnamedVariants::one(13);
     assert_eq!(EnumMultipleUnnamedVariants::One(13), one);
-    
+
     let two = EnumMultipleUnnamedVariants::two(false);
-    assert_eq!(EnumMultipleUnnamedVariants::Two(false, String::default()), two);
-    
+    assert_eq!(
+        EnumMultipleUnnamedVariants::Two(false, String::default()),
+        two
+    );
+
     let s = String::from("Test");
     let three = EnumMultipleUnnamedVariants::three(&s);
     assert_eq!(EnumMultipleUnnamedVariants::Three(s), three);

--- a/tests/enum_variant_config.rs
+++ b/tests/enum_variant_config.rs
@@ -3,14 +3,14 @@ use derive_ctor::ctor;
 #[derive(ctor, Debug, PartialEq)]
 enum SpecificVariantMethod {
     #[ctor(const pub new, other)]
-    Variant1(i32)
+    Variant1(i32),
 }
 
 #[test]
 fn test_variant_with_configured_ctors() {
     const RESULT: SpecificVariantMethod = SpecificVariantMethod::new(15);
     assert_eq!(SpecificVariantMethod::Variant1(15), RESULT);
-    
+
     let result2 = SpecificVariantMethod::other(30);
     assert_eq!(SpecificVariantMethod::Variant1(30), result2);
 }
@@ -18,8 +18,9 @@ fn test_variant_with_configured_ctors() {
 #[derive(ctor, Debug, PartialEq)]
 enum EnumNoVariantGeneration {
     Variant1,
-    #[ctor(none)] #[allow(dead_code)]
-    Variant2
+    #[ctor(none)]
+    #[allow(dead_code)]
+    Variant2,
 }
 
 #[test]
@@ -34,18 +35,18 @@ enum VariantConfigOverridesDefaults {
     Variant1,
     #[ctor(variant2)]
     Variant2,
-    #[ctor(none)] #[allow(dead_code)]
-    Variant3
+    #[ctor(none)]
+    #[allow(dead_code)]
+    Variant3,
 }
 
 #[test]
 fn test_variant_config_overrides_default_values() {
     let variant1 = VariantConfigOverridesDefaults::new_variant1();
     assert_eq!(VariantConfigOverridesDefaults::Variant1, variant1);
-    
+
     let variant2 = VariantConfigOverridesDefaults::variant2();
     assert_eq!(VariantConfigOverridesDefaults::Variant2, variant2);
-    
+
     // variant3 was not generated
 }
-

--- a/tests/struct_base.rs
+++ b/tests/struct_base.rs
@@ -15,12 +15,12 @@ pub struct Empty {}
 #[test]
 fn test_empty_struct_no_config() {
     let empty = Empty::new();
-    assert_eq!(Empty { }, empty)
+    assert_eq!(Empty {}, empty)
 }
 
 #[derive(ctor, Debug, PartialEq)]
 pub struct OneFieldStruct {
-    value: u32
+    value: u32,
 }
 
 #[test]
@@ -32,35 +32,45 @@ fn test_struct_with_field() {
 #[derive(ctor, Debug, PartialEq)]
 pub struct ManyFieldStruct {
     value1: u32,
-    value2: bool
+    value2: bool,
 }
 
 #[test]
 fn test_struct_with_many_fields() {
     let mfs = ManyFieldStruct::new(400, true);
-    assert_eq!(ManyFieldStruct { value1: 400, value2: true }, mfs);
+    assert_eq!(
+        ManyFieldStruct {
+            value1: 400,
+            value2: true
+        },
+        mfs
+    );
 }
 
 #[derive(ctor, Debug, PartialEq)]
 pub struct GenericStruct<T> {
-    item: T
+    item: T,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 pub struct WhereStruct<T>
-where T: Into<String> {
-    item: T
+where
+    T: Into<String>,
+{
+    item: T,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 pub struct StructWithClosure {
-    closure: fn(usize) -> bool
+    closure: fn(usize) -> bool,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 pub struct StructWithClosureGeneric<F>
-where F: Fn(usize) -> bool {
-    closure: F
+where
+    F: Fn(usize) -> bool,
+{
+    closure: F,
 }
 
 #[test]

--- a/tests/struct_const_ctor_config.rs
+++ b/tests/struct_const_ctor_config.rs
@@ -3,25 +3,25 @@ use derive_ctor::ctor;
 #[derive(ctor, Debug, PartialEq)]
 #[ctor(const new)]
 struct ConstStructV0 {
-    value: i32
+    value: i32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 #[ctor(const pub new)]
 struct ConstStructV1 {
-    value: i32
+    value: i32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 #[ctor(pub const new)]
 struct ConstStructV2 {
-    value: i32
+    value: i32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 #[ctor(m1, pub(crate) const m2, const m3, m4)]
 struct ConstStructMultiple {
-    value: i32
+    value: i32,
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn test_struct_with_multiple_methods() {
 
     const V2: ConstStructMultiple = ConstStructMultiple::m3(3);
     assert_eq!(ConstStructMultiple { value: 3 }, V2);
-    
+
     let v3: ConstStructMultiple = ConstStructMultiple::m4(4);
     assert_eq!(ConstStructMultiple { value: 4 }, v3);
 }

--- a/tests/struct_ctor_config.rs
+++ b/tests/struct_ctor_config.rs
@@ -6,7 +6,7 @@ struct Empty2 {}
 #[test]
 fn test_empty_struct_config_name() {
     let empty = Empty2::init();
-    assert_eq!(Empty2 { }, empty)
+    assert_eq!(Empty2 {}, empty)
 }
 
 #[derive(ctor, Debug, PartialEq)]
@@ -48,49 +48,11 @@ fn test_empty_struct_many_methods_with_visibility() {
 #[derive(ctor, Debug, PartialEq)]
 #[ctor(init)]
 struct FieldStructCustomCtor {
-    value: u32
+    value: u32,
 }
 
 #[test]
 fn test_field_struct_with_custom_ctor_name() {
     let field_struct = FieldStructCustomCtor::init(15);
     assert_eq!(FieldStructCustomCtor { value: 15 }, field_struct);
-}
-
-#[derive(Debug, PartialEq)]
-struct NoDefault {
-
-}
-
-#[derive(ctor, Debug, PartialEq)]
-#[ctor(Default)]
-struct DefaultCtorStruct {
-    #[ctor(expr(NoDefault {}))]
-    name: NoDefault,
-    #[ctor(default)]
-    value: i32
-}
-
-#[test]
-fn test_struct_with_default_ctor() {
-    let result = Default::default();
-    assert_eq!(DefaultCtorStruct { name: NoDefault {}, value: 0 }, result);
-}
-
-#[derive(ctor, Debug, PartialEq)]
-#[ctor(pub new, Default)]
-struct TestDefaultCtorWithTargetedFieldConfig {
-    #[ctor(expr(String::from("Default")) = 1)]
-    name: String,
-    #[ctor(expr(404) = 1)]
-    value: u32
-}
-
-#[test]
-fn test_struct_with_targeted_field_default_ctor() {
-    let non_default = TestDefaultCtorWithTargetedFieldConfig::new(String::from("Foo"), 505);
-    assert_eq!(TestDefaultCtorWithTargetedFieldConfig { name: String::from("Foo"), value: 505 }, non_default);
-
-    let default = Default::default();
-    assert_eq!(TestDefaultCtorWithTargetedFieldConfig { name: String::from("Default"), value: 404}, default);
 }

--- a/tests/struct_ctor_config_default.rs
+++ b/tests/struct_ctor_config_default.rs
@@ -1,0 +1,77 @@
+use derive_ctor::ctor;
+
+#[derive(Debug, PartialEq)]
+struct NoDefault {}
+
+#[derive(ctor, Debug, PartialEq)]
+#[ctor(default)]
+struct DefaultCtorStruct {
+    #[ctor(expr(NoDefault {}))]
+    name: NoDefault,
+    #[ctor(default)]
+    value: i32,
+}
+
+#[test]
+fn test_struct_with_default_ctor() {
+    let result = Default::default();
+    assert_eq!(
+        DefaultCtorStruct {
+            name: NoDefault {},
+            value: 0
+        },
+        result
+    );
+}
+
+#[derive(ctor, Debug, PartialEq)]
+#[ctor(pub new, default)]
+struct TestDefaultCtorWithTargetedFieldConfig {
+    #[ctor(expr(String::from("Default")) = 1)]
+    name: String,
+    #[ctor(expr(404) = 1)]
+    value: u32,
+}
+
+#[test]
+fn test_struct_with_targeted_field_default_ctor() {
+    let non_default = TestDefaultCtorWithTargetedFieldConfig::new(String::from("Foo"), 505);
+    assert_eq!(
+        TestDefaultCtorWithTargetedFieldConfig {
+            name: String::from("Foo"),
+            value: 505
+        },
+        non_default
+    );
+
+    let default = Default::default();
+    assert_eq!(
+        TestDefaultCtorWithTargetedFieldConfig {
+            name: String::from("Default"),
+            value: 404
+        },
+        default
+    );
+}
+
+#[derive(ctor, Debug, PartialEq)]
+#[ctor(default(all))]
+struct ImplementDefaultAllMembers {
+    name: String,
+    value: u32,
+    #[ctor(expr(NoDefault {}))]
+    no_default: NoDefault,
+}
+
+#[test]
+fn test_struct_implement_default_all_members() {
+    let result = Default::default();
+    assert_eq!(
+        ImplementDefaultAllMembers {
+            name: Default::default(),
+            value: Default::default(),
+            no_default: NoDefault {}
+        },
+        result
+    );
+}

--- a/tests/struct_field_all.rs
+++ b/tests/struct_field_all.rs
@@ -20,7 +20,7 @@ struct MixedStruct {
     #[ctor(expr("Foo"))]
     generated1: &'static str,
     #[ctor(default)]
-    generated2: u32
+    generated2: u32,
 }
 
 #[test]
@@ -28,14 +28,17 @@ fn test_struct_with_multiple_generated_fields() {
     let provided4 = String::from("Bar");
 
     let multi = MixedStruct::new(41, false, "Test", &provided4, 90, -1238);
-    assert_eq!(MixedStruct {
-        provided1: 41,
-        provided2: false,
-        provided3: String::from("Test"),
-        provided4,
-        partial1: 190,
-        partial2: true,
-        generated1: "Foo",
-        generated2: Default::default() 
-    }, multi)
+    assert_eq!(
+        MixedStruct {
+            provided1: 41,
+            provided2: false,
+            provided3: String::from("Test"),
+            provided4,
+            partial1: 190,
+            partial2: true,
+            generated1: "Foo",
+            generated2: Default::default()
+        },
+        multi
+    )
 }

--- a/tests/struct_field_cloned.rs
+++ b/tests/struct_field_cloned.rs
@@ -3,12 +3,12 @@ use derive_ctor::ctor;
 #[derive(ctor, Debug, PartialEq)]
 struct StructClone {
     #[ctor(cloned)]
-    value: String
+    value: String,
 }
 
 #[test]
 fn test_struct_clone_field() {
     let value = String::from("Foo");
     let test = StructClone::new(&value);
-    assert_eq!(StructClone { value, }, test)
+    assert_eq!(StructClone { value }, test)
 }

--- a/tests/struct_field_default.rs
+++ b/tests/struct_field_default.rs
@@ -4,7 +4,7 @@ use derive_ctor::ctor;
 struct StructDefault {
     provided: String,
     #[ctor(default)]
-    generated: u32
+    generated: u32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
@@ -13,17 +13,30 @@ struct StructManyDefault {
     #[ctor(default)]
     generated1: u32,
     #[ctor(default)]
-    generated2: String
+    generated2: String,
 }
 
 #[test]
 fn test_struct_with_default_field() {
     let test = StructDefault::new(String::from("ABC"));
-    assert_eq!(StructDefault { provided: String::from("ABC"), generated: Default::default() }, test);
+    assert_eq!(
+        StructDefault {
+            provided: String::from("ABC"),
+            generated: Default::default()
+        },
+        test
+    );
 }
 
 #[test]
 fn test_struct_with_multiple_default_fields() {
     let test = StructManyDefault::new(String::from("ABC"));
-    assert_eq!(StructManyDefault { provided: String::from("ABC"), generated1: Default::default(), generated2: Default::default() }, test);
+    assert_eq!(
+        StructManyDefault {
+            provided: String::from("ABC"),
+            generated1: Default::default(),
+            generated2: Default::default()
+        },
+        test
+    );
 }

--- a/tests/struct_field_expr.rs
+++ b/tests/struct_field_expr.rs
@@ -4,7 +4,7 @@ use derive_ctor::ctor;
 struct StructExpr {
     provided: u32,
     #[ctor(expr(10))]
-    generated: u32
+    generated: u32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
@@ -13,64 +13,89 @@ struct StructManyExpr {
     #[ctor(expr(11))]
     generated1: u32,
     #[ctor(expr(false))]
-    generated2: bool
+    generated2: bool,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 struct StructComplexExpr {
     provided: u32,
     #[ctor(expr(String::from("Foo")))]
-    generated: String
+    generated: String,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 struct StructReliantExpr {
     provided: u32,
     #[ctor(expr(provided.to_string()))]
-    generated: String
+    generated: String,
 }
 
 #[test]
 fn test_struct_expr_field() {
     let test = StructExpr::new(100);
-    assert_eq!(StructExpr { provided: 100, generated: 10 }, test);
+    assert_eq!(
+        StructExpr {
+            provided: 100,
+            generated: 10
+        },
+        test
+    );
 }
 
 #[test]
 fn test_struct_many_expr_fields() {
     let test = StructManyExpr::new(101);
-    assert_eq!(StructManyExpr { provided: 101, generated1: 11, generated2: false }, test);
+    assert_eq!(
+        StructManyExpr {
+            provided: 101,
+            generated1: 11,
+            generated2: false
+        },
+        test
+    );
 }
 
 #[test]
 fn test_struct_complex_expr_field() {
     let test = StructComplexExpr::new(102);
-    assert_eq!(StructComplexExpr { provided: 102, generated: String::from("Foo") }, test);
+    assert_eq!(
+        StructComplexExpr {
+            provided: 102,
+            generated: String::from("Foo")
+        },
+        test
+    );
 }
 
 #[test]
 fn test_struct_reliant_expr_field() {
     let test = StructReliantExpr::new(103);
-    assert_eq!(StructReliantExpr { provided: 103, generated: 103.to_string() }, test);
+    assert_eq!(
+        StructReliantExpr {
+            provided: 103,
+            generated: 103.to_string()
+        },
+        test
+    );
 }
 
 #[derive(ctor, Debug, PartialEq)]
 struct SelfRefExpr {
     #[ctor(expr!(value - 1))]
-    value: u32
+    value: u32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 struct ComplexSelfRefExpr {
     #[ctor(expr!(n1 - n2))]
     n1: u32,
-    n2: u32
+    n2: u32,
 }
 
 #[derive(ctor, Debug, PartialEq)]
 struct ChangeInputTypeExpr {
     #[ctor(expr(String -> Box::new(value)))]
-    value: Box<String>
+    value: Box<String>,
 }
 
 #[test]
@@ -88,5 +113,10 @@ fn test_complex_self_referencing_expr_field() {
 #[test]
 fn test_changed_input_type() {
     let test = ChangeInputTypeExpr::new(String::from("ABC"));
-    assert_eq!(ChangeInputTypeExpr { value: Box::new(String::from("ABC"))}, test)
+    assert_eq!(
+        ChangeInputTypeExpr {
+            value: Box::new(String::from("ABC"))
+        },
+        test
+    )
 }

--- a/tests/struct_field_into.rs
+++ b/tests/struct_field_into.rs
@@ -4,7 +4,7 @@ use derive_ctor::ctor;
 struct StructImpl {
     #[ctor(into)]
     provided: String,
-    other: bool
+    other: bool,
 }
 
 #[derive(ctor, Debug, PartialEq)]
@@ -13,17 +13,30 @@ struct StructManyImpl {
     #[ctor(into)]
     one: String,
     #[ctor(into)]
-    two: String
+    two: String,
 }
 
 #[test]
 fn test_struct_with_impl_value() {
     let test = StructImpl::new("Foo", false);
-    assert_eq!(StructImpl { provided: String::from("Foo"), other: false }, test);
+    assert_eq!(
+        StructImpl {
+            provided: String::from("Foo"),
+            other: false
+        },
+        test
+    );
 }
 
 #[test]
 fn test_struct_with_many_impl() {
     let test = StructManyImpl::new(false, "One", "Two");
-    assert_eq!(StructManyImpl { provided: false, one: String::from("One"), two: String::from("Two") }, test)
+    assert_eq!(
+        StructManyImpl {
+            provided: false,
+            one: String::from("One"),
+            two: String::from("Two")
+        },
+        test
+    )
 }

--- a/tests/struct_field_iter.rs
+++ b/tests/struct_field_iter.rs
@@ -5,7 +5,7 @@ use derive_ctor::ctor;
 #[derive(ctor, Debug, PartialEq)]
 struct StructIter {
     #[ctor(iter(usize))]
-    collection: HashSet<usize>
+    collection: HashSet<usize>,
 }
 
 #[test]
@@ -17,5 +17,10 @@ fn test_struct_with_field_iter() {
     expected_set.insert(3);
     expected_set.insert(6);
 
-    assert_eq!(StructIter { collection: expected_set }, test);
+    assert_eq!(
+        StructIter {
+            collection: expected_set
+        },
+        test
+    );
 }

--- a/tests/struct_field_specific_ctor.rs
+++ b/tests/struct_field_specific_ctor.rs
@@ -5,13 +5,19 @@ use derive_ctor::ctor;
 struct TargetedGenerationStruct {
     arg1: u32,
     #[ctor(default = [0])]
-    arg2: u32
+    arg2: u32,
 }
 
 #[test]
 fn test_struct_with_targeted_generation() {
     let targeted = TargetedGenerationStruct::new(100);
-    assert_eq!(TargetedGenerationStruct { arg1: 100, arg2: Default::default() }, targeted);
+    assert_eq!(
+        TargetedGenerationStruct {
+            arg1: 100,
+            arg2: Default::default()
+        },
+        targeted
+    );
     let targeted2 = TargetedGenerationStruct::new2(50, 41);
     assert_eq!(TargetedGenerationStruct { arg1: 50, arg2: 41 }, targeted2);
 }
@@ -26,16 +32,28 @@ struct TargetedGenerationStruct2 {
     #[ctor(expr(test_method_2()) = [1])]
     arg1: String,
     #[ctor(expr(33) = 0)]
-    arg2: u32
+    arg2: u32,
 }
 
 #[test]
 fn test_struct_with_multiple_targeted_generations() {
     let tgs1 = TargetedGenerationStruct2::new(String::from("one"));
-    assert_eq!(TargetedGenerationStruct2 { arg1: String::from("one"), arg2: 33 }, tgs1);
+    assert_eq!(
+        TargetedGenerationStruct2 {
+            arg1: String::from("one"),
+            arg2: 33
+        },
+        tgs1
+    );
 
     let tgs2 = TargetedGenerationStruct2::new2(95);
-    assert_eq!(TargetedGenerationStruct2 { arg1: String::from("FooBar"), arg2: 95}, tgs2);
+    assert_eq!(
+        TargetedGenerationStruct2 {
+            arg1: String::from("FooBar"),
+            arg2: 95
+        },
+        tgs2
+    );
 }
 
 #[derive(ctor, Debug, PartialEq)]
@@ -44,17 +62,35 @@ struct TestStructWithFieldWithMultipleTargets {
     #[ctor(into)]
     arg1: String,
     #[ctor(expr(5) = [0, 1])]
-    arg2: u32
+    arg2: u32,
 }
 
 #[test]
 fn test_struct_multiple_targeted_generations_single_field() {
     let tswfwmt1 = TestStructWithFieldWithMultipleTargets::m1("One");
-    assert_eq!(TestStructWithFieldWithMultipleTargets { arg1: String::from("One"), arg2: 5 }, tswfwmt1);
+    assert_eq!(
+        TestStructWithFieldWithMultipleTargets {
+            arg1: String::from("One"),
+            arg2: 5
+        },
+        tswfwmt1
+    );
 
     let tswfwmt1 = TestStructWithFieldWithMultipleTargets::m2("Two");
-    assert_eq!(TestStructWithFieldWithMultipleTargets { arg1: String::from("Two"), arg2: 5 }, tswfwmt1);
+    assert_eq!(
+        TestStructWithFieldWithMultipleTargets {
+            arg1: String::from("Two"),
+            arg2: 5
+        },
+        tswfwmt1
+    );
 
     let tswfwmt1 = TestStructWithFieldWithMultipleTargets::m3("Three", 77);
-    assert_eq!(TestStructWithFieldWithMultipleTargets { arg1: String::from("Three"), arg2: 77 }, tswfwmt1);
+    assert_eq!(
+        TestStructWithFieldWithMultipleTargets {
+            arg1: String::from("Three"),
+            arg2: 77
+        },
+        tswfwmt1
+    );
 }

--- a/tests/struct_mixed_method_field.rs
+++ b/tests/struct_mixed_method_field.rs
@@ -5,11 +5,17 @@ use derive_ctor::ctor;
 struct MixedCtorFieldStruct {
     provided: u32,
     #[ctor(default)]
-    generated: bool
+    generated: bool,
 }
 
 #[test]
 fn test_struct_with_custom_ctor_and_generated_field() {
     let test = MixedCtorFieldStruct::a(100);
-    assert_eq!(MixedCtorFieldStruct { provided: 100, generated: false }, test)
+    assert_eq!(
+        MixedCtorFieldStruct {
+            provided: 100,
+            generated: false
+        },
+        test
+    )
 }

--- a/tests/struct_phantom_data.rs
+++ b/tests/struct_phantom_data.rs
@@ -1,14 +1,20 @@
-use std::marker::PhantomData;
 use derive_ctor::ctor;
+use std::marker::PhantomData;
 
 #[derive(ctor, Debug, PartialEq)]
 struct HasPhantomData {
     value: u32,
-    _marker: PhantomData<u32>
+    _marker: PhantomData<u32>,
 }
 
 #[test]
 fn test_phantom_data_auto_excluded_as_parameter() {
     let pd = HasPhantomData::new(4);
-    assert_eq!(HasPhantomData { value: 4, _marker: PhantomData }, pd)
+    assert_eq!(
+        HasPhantomData {
+            value: 4,
+            _marker: PhantomData
+        },
+        pd
+    )
 }


### PR DESCRIPTION
- renamed `Default` trait configuration in ctor from `Default` to `default`
- added `default(all)` as a variation which marks all fields w/o attributes as `#[ctor(default)]`
- split struct and enum support into two separate default features ("structs" and "enums")
- formatted code with rustfmt