### PR TITLE
Release 1.0.1 - Fix Keyword Enum Variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "derive-ctor"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-ctor"
-version = "1.0.0"
+version = "1.0.1"
 description = "Adds `#[derive(ctor)]` which allows for the auto-generation of struct, enum, and union constructors."
 keywords = ["derive", "macro", "trait", "procedural", "no_std"]
 authors = ["Evan Cowin"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `derive-ctor` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-derive-ctor = "1.0.0"
+derive-ctor = "1.0.1"
 ```
 
 Annotate your struct with `#[derive(ctor)]` to automatically generate a `new` constructor:
@@ -161,7 +161,7 @@ union MyUnion {
     v3: u32
 }
 
-const VAL: MyUnion = MyUnion::new(100);
+const VAL地震: MyUnion = MyUnion::new(100);
 let v2 = MyUnion::new_v2(123.231);
 let v3 = MyUnion::new_v3(414224); 
 ```

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -8,7 +8,7 @@ use heck::ToSnakeCase;
 
 use crate::constants::{CONFIG_PROP_ERR_MSG, ENUM_PROP_VIS as VIS, ENUM_PROP_VISIBILITY as VISIBILITY, ENUM_PROP_PREFIX as PREFIX};
 use crate::structs::CtorStructConfiguration;
-use crate::{CtorAttribute, CtorDefinition, try_parse_attributes_with_default};
+use crate::{adjust_keyword_ident, CtorAttribute, CtorDefinition, try_parse_attributes_with_default};
 use crate::fields::generate_ctor_meta;
 
 use proc_macro2::Span;
@@ -205,7 +205,7 @@ fn convert_to_snakecase(method_ident: Ident) -> Result<Ident, Error> {
         + &ident_string.to_snake_case()
         + &"_".repeat(trailing_underscore_count);
 
-    syn::parse_str(&snake_case)
+    syn::parse_str(&adjust_keyword_ident(snake_case))
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 extern crate alloc;
 use alloc::format;
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use alloc::collections::BTreeSet as HashSet;
 
 use crate::constants::CTOR_WORD;
@@ -143,9 +143,24 @@ where
     expression(&buffer)
 }
 
+pub(crate) fn adjust_keyword_ident(name: String) -> String {
+    if syn::parse_str::<Ident>(&name).is_ok() {
+        return name;
+    }
+    format!("r#{}", name)
+}
+
 #[test]
 fn test_is_phantom_data() {
     assert!(is_phantom_data(&syn::parse_str::<Type>("PhantomData").unwrap()));
     assert!(is_phantom_data(&syn::parse_str::<Type>("&mut PhantomData<&'static str>").unwrap()));
     assert!(!is_phantom_data(&syn::parse_str::<Type>("i32").unwrap()));
+}
+
+#[test]
+fn test_adjust_keyword_ident() {
+    assert_eq!("abc".to_string(), adjust_keyword_ident("abc".to_string()));
+    assert_eq!("r#break".to_string(), adjust_keyword_ident("break".to_string()));
+    assert_eq!("r#fn".to_string(), adjust_keyword_ident("fn".to_string()));
+    assert_eq!("r#const".to_string(), adjust_keyword_ident("const".to_string()));
 }

--- a/tests/enum_base.rs
+++ b/tests/enum_base.rs
@@ -45,3 +45,20 @@ fn test_enum_multiple_variants() {
     let v3 = MultipleVariants::variant3(888);
     assert_eq!(MultipleVariants::Variant3 { value: 888 }, v3);
 }
+
+
+#[derive(ctor, Debug, PartialEq)]
+enum KeywordVariants {
+    Break,
+    Continue,
+    Return,
+    Fn
+}
+
+#[test]
+fn test_enum_with_keyword_names() {
+    assert_eq!(KeywordVariants::Break, KeywordVariants::r#break());
+    assert_eq!(KeywordVariants::Continue, KeywordVariants::r#continue());
+    assert_eq!(KeywordVariants::Return, KeywordVariants::r#return());
+    assert_eq!(KeywordVariants::Fn, KeywordVariants::r#fn());
+}

--- a/tests/union.rs
+++ b/tests/union.rs
@@ -67,9 +67,3 @@ fn test_union_override() {
     let v3 = UnionOverride::new_other(181);
     unsafe { assert_eq!(v3.other, 181); }
 }
-
-#[derive(ctor)]
-union UnionDefault {
-    #[ctor(default)]
-    int: i32
-}


### PR DESCRIPTION
- fixed issue where enum variants named keywords (e.g. Break) would cause issues due to the generated method name
- removed unused struct from test case