### PR TITLE
Fix Self-Ref Expressions with `default(all)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "derive-ctor"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-ctor"
-version = "1.0.3"
+version = "1.0.4"
 description = "Adds `#[derive(ctor)]` which allows for the auto-generation of struct, enum, and union constructors."
 keywords = ["derive", "macro", "trait", "procedural", "no_std"]
 authors = ["Evan Cowin"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `derive-ctor` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-derive-ctor = "1.0.3"
+derive-ctor = "1.0.4"
 ```
 
 Annotate your struct with `#[derive(ctor)]` to automatically generate a `new` constructor:

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -137,7 +137,7 @@ impl FieldConfigProperty {
             FieldConfigProperty::Default => true,
             FieldConfigProperty::Into => false,
             FieldConfigProperty::Iter { .. } => false,
-            FieldConfigProperty::Expression { .. } => true
+            FieldConfigProperty::Expression { self_referencing, .. } => !self_referencing
         }
     }
 }

--- a/tests/struct_ctor_config_default.rs
+++ b/tests/struct_ctor_config_default.rs
@@ -62,7 +62,9 @@ struct ImplementDefaultAllMembers {
     #[ctor(expr(NoDefault {}))]
     no_default: NoDefault,
     #[ctor(into)]
-    provided: String
+    provided: String,
+    #[ctor(expr!(adjusted - 10))]
+    adjusted: i32
 }
 
 #[test]
@@ -73,8 +75,10 @@ fn test_struct_implement_default_all_members() {
             name: Default::default(),
             value: Default::default(),
             no_default: NoDefault {},
-            provided: Default::default()
+            provided: Default::default(),
+            adjusted: 0,
         },
         result
     );
 }
+


### PR DESCRIPTION
Fixed an issue where self referencing expressions would cause issues with `default(all)`