### PR TITLE
Added new named ctor properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "derive-ctor"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-ctor"
-version = "1.0.4"
+version = "1.0.5"
 description = "Adds `#[derive(ctor)]` which allows for the auto-generation of struct, enum, and union constructors."
 keywords = ["derive", "macro", "trait", "procedural", "no_std"]
 authors = ["Evan Cowin"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add `derive-ctor` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-derive-ctor = "1.0.4"
+derive-ctor = "1.0.5"
 ```
 
 Annotate your struct with `#[derive(ctor)]` to automatically generate a `new` constructor:
@@ -95,6 +95,26 @@ struct OtherStruct {
 }
 
 let default2: OtherStruct = Default::default();
+```
+
+### Constructor Properties
+Custom constructor definitions can also take one of the following properties to implement on all non-configured fields
+- **default** - Marks all non-annotated fields as `#[ctor(default)]`
+- **into** - Marks all non-annotated fields as `#[ctor(into)]`
+
+```rust
+use derive_ctor::ctor;
+
+#[derive(ctor)]
+#[ctor(new(into), with_defaults(default))]
+struct MyStruct {
+    name: String,
+    #[ctor(expr(13))]
+    value: i32
+}
+
+let example1 = MyStruct::new("FooBar");
+let example2 = MyStruct::with_defaults();
 ```
 
 ## Enum and Union Configurations

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,6 +26,7 @@ pub(crate) const ENUM_PROP_VIS: &str = "vis";
 pub(crate) const ENUM_VARIATION_PROP_NONE: &str = "none";
 
 // struct config properties
+pub(crate) const STRUCT_PROP_INTO: &str = "into";
 pub(crate) const STRUCT_PROP_DEFAULT: &str = "default";
 // property used within the default() prop
 pub(crate) const NESTED_PROP_ALL: &str = "all";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) enum CtorAttribute {
     Const,
     DefaultAll,
     Default,
+    IntoAll,
 }
 
 impl Default for CtorDefinition {

--- a/tests/struct_ctor_config_default.rs
+++ b/tests/struct_ctor_config_default.rs
@@ -82,3 +82,20 @@ fn test_struct_implement_default_all_members() {
     );
 }
 
+#[derive(ctor, Debug, PartialEq)]
+#[ctor(with_defaults(default), new(into))]
+struct CtorNestedProperties {
+    name: String,
+    #[ctor(expr!(value + 1))]
+    value: u32
+}
+
+#[test]
+fn test_struct_with_nested_properties() {
+    let test1 = CtorNestedProperties::with_defaults();
+    assert_eq!(CtorNestedProperties { name: String::default(), value: 0 }, test1);
+    
+    let test2 = CtorNestedProperties::new("FooBar", 30);
+    assert_eq!(CtorNestedProperties { name: String::from("FooBar"), value: 31 },  test2)
+    
+}


### PR DESCRIPTION
Added 2 named ctor properties `#[ctor(pub new(PROPERTY)]`
- into - marks all non-annotated fields as `#[ctor(into)]`
- default - marks all non-annotated fields as `#[ctor(default)]`